### PR TITLE
Update shentu bech32 prefix to shentu

### DIFF
--- a/packages/cosmos-snap-provider/src/constants/chainInfo.ts
+++ b/packages/cosmos-snap-provider/src/constants/chainInfo.ts
@@ -1011,7 +1011,7 @@ const Chains = {
     chainId: 'shentu-2.2',
     chainName: 'shentu',
     bech32Config: {
-      bech32PrefixAccAddr: 'certik',
+      bech32PrefixAccAddr: 'shentu',
     },
     bip44: {
       coinType: 118,

--- a/packages/snap/src/constants/chainInfo.ts
+++ b/packages/snap/src/constants/chainInfo.ts
@@ -843,7 +843,7 @@ const Chains = {
     chainId: 'shentu-2.2',
     chainName: 'shentu',
     bech32Config: {
-      bech32PrefixAccAddr: 'certik',
+      bech32PrefixAccAddr: 'shentu',
     },
     bip44: {
       coinType: 118,


### PR DESCRIPTION
Shentu prefix was updated in version 2.8.0, see https://github.com/shentufoundation/shentu/releases/
`Version 2.8.0 changes the Bech32 address prefix to 'shentu'.`

Using the certik prefix causes issues with rest endpoints, for example `https://shentu-rest.publicnode.com/cosmos/staking/v1beta1/delegations/certik1npauvhjz4zm4pejsquh3ey3lh3ec207k7p978e?pagination.limit=1000`

Updating `bech32PrefixAccAddr` should be sufficient as the value is passed to `packages/snap/src/wallet/wallet.ts#create` method in  `addressPrefix` which will generate the correct public address.